### PR TITLE
Prevent writing data for HEAD requests and write to res.statusCode for connect's logger

### DIFF
--- a/lib/quip.js
+++ b/lib/quip.js
@@ -1,12 +1,18 @@
 // filter for use with Connect
 var exports = module.exports = function(){
     return function(req, res, next){
-        exports.update(res, req);
+        exports.update(res);
+        // proxy write to prevent writing on HEAD requests
+        var write = res.write;
+        res.write = function(chunk, encoding) {
+            if (req.method == 'HEAD') return true;
+            return write(chunk, encoding);
+        };
         next();
     };
 };
 
-exports.update = function(res, req){
+exports.update = function(res){
 
     ///// default response settings /////
     res._quip_headers = {'Content-Type': 'text/html'};
@@ -104,7 +110,7 @@ exports.update = function(res, req){
             if(typeof data == 'object') data = JSON.stringify(data);
         }
         res.writeHead(res._quip_status, res._quip_headers);
-        if(data && req.method != 'HEAD') res.write(data);
+        if(data) res.write(data);
         res.end();
         return null;
     };


### PR DESCRIPTION
Since we're writing data to the request within quip, the middleware should prevent writing data if it is responding to a HEAD request.

Connect's logger uses res.statusCode, so we should write the statusCode on the response so the logger can report properly.
