### PR TITLE
statusCode and HEAD requests

### DIFF
--- a/lib/quip.js
+++ b/lib/quip.js
@@ -2,6 +2,13 @@
 var exports = module.exports = function(){
     return function(req, res, next){
         exports.update(res);
+        // proxy write to prevent writing on HEAD requests
+        var write = res.write;
+        res.write = function(chunk, encoding) {
+            res.write = write;
+            if (req.method == 'HEAD') return true;
+            return res.write(chunk, encoding);
+        };
         next();
     };
 };
@@ -46,7 +53,8 @@ exports.update = function(res){
 
     ///// exported methods /////
     res.status = function(code){
-        res._quip_status = code;
+        // set statusCode on res so other middleware (such as logger) can access it
+        res._quip_status = res.statusCode = code;
         return res;
     };
     res.headers = function(headers){


### PR DESCRIPTION
I've modified quip to handle two scenarios it wasn't handling as well as it could:
1. Since quip didn't set res.statusCode, other middleware such as connect's logger couldn't read the statusCode and therefore reported improper status codes.
2. Since quip provides a response body for redirections, it needs to prevent writing to the body when dealing with a HEAD request.  I've now corrected the middleware to not write if the request is a HEAD request.
