### PR TITLE
Fixed npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   { "type" : "git"
   , "url" : "http://github.com/caolan/quip.git"
   }
-, "bugs" : { "web" : "http://github.com/caolan/quip/issues" }
+, "bugs" : { "url" : "http://github.com/caolan/quip/issues" }
 , "licenses" :
   [ { "type" : "MIT"
     , "url" : "http://github.com/caolan/quip/raw/master/LICENSE"


### PR DESCRIPTION
npm WARN quip@0.0.2 package.json: bugs['web'] should probably be bugs['url']
