### PR TITLE
Fixed `TypeError: Argument must be a string` when call res.send() with Buffer as an argument

### DIFF
--- a/lib/quip.js
+++ b/lib/quip.js
@@ -104,7 +104,7 @@ exports.update = function(res){
             if(typeof data == 'object') data = JSON.stringify(data);
         }
         if(data) {
-            res._quip_headers['Content-Length'] = Buffer.byteLength(data);
+            res._quip_headers['Content-Length'] = Buffer.isBuffer(data)? data.length : Buffer.byteLength(data);
         }
         res.writeHead(res._quip_status, res._quip_headers);
         if(data) res.write(data);


### PR DESCRIPTION
In v0.0.3, I can call `res.send(buffer)` with Buffer object. 
v0.0.4 breaks this line due to `Buffer.byteLength` which takes only String as an argument and it results in `TypeError: Argument must be a string.
