### PR TITLE
Fixed parametrs list for callback next

### DIFF
--- a/lib/quip.js
+++ b/lib/quip.js
@@ -142,7 +142,7 @@ module.exports = function (req, res, next) {
 
     if (next) {
         // pass updated response object onto next connect middleware
-        next(req, res, next);
+        next(null, res);
     }
     else {
         // called directly, return updated response object


### PR DESCRIPTION
Hi! I use quip with connect.
But after updated quip to version 0.1.0, I had 500 status code on all requests to the server. After debugging I found that callback next wait that first parameter is null or error. 
