### PR TITLE
Fix 204 no content

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ type of the response will be updated accordingly.
 * res.ok
 * res.created
 * res.accepted
+* res.noContent
 
 #### Redirection
 * res.moved

--- a/lib/quip.js
+++ b/lib/quip.js
@@ -20,6 +20,11 @@ module.exports = function (req, res, next) {
                           res.status(code);
         };
     };
+    var withStatusAndSend = function (code) {
+        return function (data) {
+            return res.status(code).send();
+        };
+    };
     var redirection = function (code, message) {
         return function (loc) {
             res._quip_headers.Location = loc;
@@ -61,7 +66,7 @@ module.exports = function (req, res, next) {
     res.ok = withStatus(200);
     res.created = withStatus(201);
     res.accepted = withStatus(202);
-    res.noContent = withStatus(204);
+    res.noContent = withStatusAndSend(204);
 
     // redirection
     res.moved = redirection(301, 'Moved Permanently');
@@ -134,6 +139,9 @@ module.exports = function (req, res, next) {
                 }
                 res._quip_headers['Content-Length'] = Buffer.byteLength(data);
             }
+        } else {
+          // set headers even if there is no data! 204 No Content needs it.
+          res.writeHead(res._quip_status, res._quip_headers);
         }
         if (!res._quip_headers['Content-Type']) {
             // assume HTML if data is a string and content type not set

--- a/lib/quip.js
+++ b/lib/quip.js
@@ -61,6 +61,7 @@ module.exports = function (req, res, next) {
     res.ok = withStatus(200);
     res.created = withStatus(201);
     res.accepted = withStatus(202);
+    res.noContent = withStatus(204);
 
     // redirection
     res.moved = redirection(301, 'Moved Permanently');


### PR DESCRIPTION
Adds a `res.noContent()` method which sets the status to 204 and sends immediately.
- had to add a new method similar to `withStatus` since withStatus does not send when no data is passed in.
- fixed `send` method to properly set the headers with the quip_status when it was called without passing in data.
